### PR TITLE
created stackover flow test

### DIFF
--- a/LinqSpecs.Tests/StackoverflowTest.cs
+++ b/LinqSpecs.Tests/StackoverflowTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using NUnit.Framework;
+
+namespace LinqSpecs.Tests
+{
+    public class StackoverflowTest
+    {
+        [Test]
+        public void RecreateStackOverFlow()
+        {
+            var customSpec = new CustomSpec("Jose");
+            Assert.True(true); //!!!!Put a break point here and let it sit for a second or two, you'll stack overflow
+        }
+    }
+
+
+    public class CustomSpec : Specification<string>
+    {
+        public string Name { get; set; }
+
+        public CustomSpec(string name)
+        {
+            Name = name;
+        }
+
+        public override Expression<Func<string, bool>> ToExpression()
+        {
+            return s => s == Name;
+        }
+    }
+}


### PR DESCRIPTION
Make sure to pause the debugger on the Assert.True(true), after sitting there for a second or two you'll get a stack overflow. I'm using .NET Framework 4 and NUnit 3.10.1. I'm running this code on 64bit Windows 10 

I wish there was a cleaner way to show this happening, but I can't find a clean way of catching a stackoverflow in a unit test