### PR TITLE
Combine specification with (LINQ) predicate

### DIFF
--- a/LinqSpecs.DatabaseTests/Tests.cs
+++ b/LinqSpecs.DatabaseTests/Tests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 namespace LinqSpecs.DatabaseTests
@@ -72,6 +74,19 @@ namespace LinqSpecs.DatabaseTests
             var hasMultipleOrdersSpec = new AdHocSpecification<Customer>(x => x.Orders.Count() > 1);
             var highTotalPriceSpec = new AdHocSpecification<Customer>(x => x.Orders.Sum(y => y.Price) > 500);
             var vipSpec = hasMultipleOrdersSpec && highTotalPriceSpec;
+
+            var customers = db.Customers.Where(vipSpec).Select(x => x.Name).ToList();
+
+            Assert.That(customers, Is.EquivalentTo(new[] { "Triple-order Customer" }));
+        }
+
+        [Test]
+        public void СombinedSpecificationWithPredicate()
+        {
+            using var db = new SampleDbContext();
+            var hasMultipleOrdersSpec = new AdHocSpecification<Customer>(x => x.Orders.Count() > 1);
+            Expression<Func<Customer,bool>> highTotalPriceSpec = x => x.Orders.Sum(y => y.Price) > 500;
+            var vipSpec = hasMultipleOrdersSpec & highTotalPriceSpec;
 
             var customers = db.Customers.Where(vipSpec).Select(x => x.Name).ToList();
 

--- a/LinqSpecs.UnitTests/BooleanOperators/AndSpecificationTests.cs
+++ b/LinqSpecs.UnitTests/BooleanOperators/AndSpecificationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 namespace LinqSpecs.Tests
@@ -47,6 +48,28 @@ namespace LinqSpecs.Tests
         }
 
         [Test]
+        public void Equals_returns_true_when_both_sides_are_equals_and_left_side_is_predicate()
+        {
+            var s1 = new AdHocSpecification<string>(x => x.Length > 1);
+            Expression<Func<string,bool>> s2 = x => x.Length > 2;
+            var spec = s1 & s2;
+
+            Assert.IsInstanceOf<AndSpecification<string>>(spec);
+            Assert.IsTrue(spec.Equals(spec));
+        }
+
+        [Test]
+        public void Equals_returns_true_when_both_sides_are_equals_and_right_side_is_predicate()
+        {
+            Expression<Func<string, bool>> s1 = x => x.Length > 1;
+            var s2 = new AdHocSpecification<string>(x => x.Length > 2);
+            var spec = s1 & s2;
+
+            Assert.IsInstanceOf<AndSpecification<string>>(spec);
+            Assert.IsTrue(spec.Equals(spec));
+        }
+
+        [Test]
         public void Equals_returns_false_when_both_sides_are_not_equals()
         {
             var s1 = new AdHocSpecification<string>(x => x.Length > 1);
@@ -65,7 +88,7 @@ namespace LinqSpecs.Tests
         }
 
         [Test]
-        public void GetHashCode_retuns_same_value_for_equal_specifications()
+        public void GetHashCode_returns_same_value_for_equal_specifications()
         {
             var s1 = new AdHocSpecification<string>(x => x.Length > 1);
             var s2 = new AdHocSpecification<string>(x => x.Length > 2);

--- a/LinqSpecs/Specification.cs
+++ b/LinqSpecs/Specification.cs
@@ -46,7 +46,7 @@ namespace LinqSpecs
         }
 
         /// <summary>
-        /// Allows to combine two query specifications using a logical AND operation.
+        /// Combines two query specifications using a logical AND operation.
         /// </summary>
         public static Specification<T> operator &(Specification<T> spec1, Specification<T> spec2)
         {
@@ -54,11 +54,43 @@ namespace LinqSpecs
         }
 
         /// <summary>
-        /// Allows to combine two query specifications using a logical OR operation.
+        /// Combines a query specification with a lambda predicate using a logical AND operation.
+        /// </summary>
+        public static Specification<T> operator &(Specification<T> spec, Expression<Func<T,bool>> predicate)
+        {
+            return new AndSpecification<T>(spec, new AdHocSpecification<T>(predicate));
+        }
+
+        /// <summary>
+        /// Combines a query specification with a lambda predicate using a logical AND operation.
+        /// </summary>
+        public static Specification<T> operator &(Expression<Func<T, bool>> predicate, Specification<T> spec)
+        {
+            return new AndSpecification<T>(new AdHocSpecification<T>(predicate), spec);
+        }
+
+        /// <summary>
+        /// Combines two query specifications using a logical OR operation.
         /// </summary>
         public static Specification<T> operator |(Specification<T> spec1, Specification<T> spec2)
         {
             return new OrSpecification<T>(spec1, spec2);
+        }
+
+        /// <summary>
+        /// Combines a query specification with a lambda predicate using a logical OR operation.
+        /// </summary>
+        public static Specification<T> operator |(Specification<T> spec, Expression<Func<T, bool>> predicate)
+        {
+            return new OrSpecification<T>(spec, new AdHocSpecification<T>(predicate));
+        }
+
+        /// <summary>
+        /// Combines a query specification with a lambda predicate using a logical OR operation.
+        /// </summary>
+        public static Specification<T> operator |(Expression<Func<T, bool>> predicate, Specification<T> spec)
+        {
+            return new OrSpecification<T>(new AdHocSpecification<T>(predicate), spec);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows combining not only two specifications, but also one specification and one lambda predicate